### PR TITLE
fix: clear stale cursor state after drag-drop to world

### DIFF
--- a/src/KenshiRotate.cpp
+++ b/src/KenshiRotate.cpp
@@ -354,8 +354,11 @@ void InventoryGUI_update_hook(InventoryGUI* thisptr)
 	MouseInventoryAccess::FindShadowWidget();
 	MouseInventoryAccess::FindMouseInventory();
 
-	// Cache hovered rotated item position for pickup offset correction.
-	// Only runs when no item is held on cursor.
+	// Detect stale cursor state: dropping an item to the game world bypasses
+	// placeItemFromMouse, leaving CursorState with dangling pointers.
+	if (CursorState::IsHolding() && MouseInventoryAccess::IsReady() && !MouseInventoryAccess::HasHeldItem())
+		CursorState::Clear();
+
 	if (!CursorState::IsHolding())
 	{
 		CursorState::ClearHoverPos();

--- a/src/MouseInventoryAccess.cpp
+++ b/src/MouseInventoryAccess.cpp
@@ -141,3 +141,11 @@ bool MouseInventoryAccess::IsReady()
 {
 	return s_mouseInventory != NULL;
 }
+
+bool MouseInventoryAccess::HasHeldItem()
+{
+	if (!s_mouseInventory)
+		return false;
+	void* item = *reinterpret_cast<void**>(reinterpret_cast<char*>(s_mouseInventory) + OFF_HELD_ITEM);
+	return item != NULL;
+}

--- a/src/MouseInventoryAccess.h
+++ b/src/MouseInventoryAccess.h
@@ -11,6 +11,7 @@ public:
 	static void SetGrabOffset(int x, int y);
 	static MyGUI::Widget* GetShadowWidget();
 	static bool IsReady();
+	static bool HasHeldItem();
 
 private:
 	static void* s_mouseInventory;


### PR DESCRIPTION
Closes #2 